### PR TITLE
Add GitHub Enterprise, assignee and issue state

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ program
 
             // abuse rate limits apply for concurrent content creation
             // requests by a single GitHub user.
-            var limiter = new Bottleneck(20,200);
-
+            var limiter = new Bottleneck(5,500);
+            
             // OAuth2
             github.authenticate({
                 type: "oauth",

--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ program
                     var bodyIndex = cols.indexOf('description');
                     var labelsIndex = cols.indexOf('labels');
                     var milestoneIndex = cols.indexOf('milestone');
+                    var assigneeIndex = cols.indexOf('assignee');
 
                     if (titleIndex === -1) {
                         console.error('Title required by GitHub, but not found in CSV.');
@@ -95,6 +96,11 @@ program
                         // if we have a milestone column, pass that.
                         if (milestoneIndex > -1 && row[milestoneIndex] !== '') {
                             sendObj.milestone = row[milestoneIndex];
+                        }
+                        
+                        // if we have an assignee column, pass that.
+                        if (assigneeIndex > -1 && row[assigneeIndex] !== '') {
+                            sendObj.assignee = row[assigneeIndex];
                         }
 
                         limiter.submit(github.issues.create,sendObj, function(err, res)

--- a/index.js
+++ b/index.js
@@ -10,13 +10,21 @@ const fs = require('fs');
 const Bottleneck = require("bottleneck");
 
 program
-    .version('0.1.0')
+    .version('0.2.0')
     .arguments('<file>')
-    .option('-t, --token <token>', 'The GitHub token. https://github.com/settings/tokens')
-    .action(function(file) {
+    .option('--github_enterprise [github.my-company.com]')
+    .option('--token [token]', 'The GitHub token. https://github.com/settings/tokens')
+    .action(function(file, options) {
         co(function*() {
             var retObject = {};
-            retObject.token = yield prompt('token (get from https://github.com/settings/tokens): ');
+            retObject.githubUrl = options.github_enterprise || "github.com";
+            if (retObject.githubUrl != 'github.com') {
+              retObject.pathPrefix = "/api/v3"
+            }
+            retObject.token = options.token || "";
+            if (retObject.token == "") {
+              retObject.token = yield prompt('token (get from https://' + retObject.githubUrl + '/settings/tokens): ');
+            };
             retObject.userOrOrganization = yield prompt('user or organization: ');
             retObject.repo = yield prompt('repo: ');
             return retObject;
@@ -25,9 +33,10 @@ program
                 // required
                 version: '3.0.0',
                 // optional
+                pathPrefix: values.pathPrefix, 
                 debug: true,
                 protocol: 'https',
-                host: 'api.github.com',
+                host: values.githubUrl,
                 timeout: 5000,
                 headers: {
                     'user-agent': 'My-Cool-GitHub-App' // GitHub is happy with a unique user agent

--- a/test/3.csv
+++ b/test/3.csv
@@ -1,0 +1,3 @@
+title,description,labels,state
+Test 1, This is the test1 desc, bug,open
+Test 2, This is the test2 desc, "question,bug",closed

--- a/test/4.csv
+++ b/test/4.csv
@@ -1,0 +1,3 @@
+title,description,labels,assignee
+Test 1, This is the test1 desc, bug,github-user
+Test 2, This is the test2 desc, "question,bug",github-user


### PR DESCRIPTION
Thanks for this nice little tool!
Here is my contribution:
- Add support for GitHub enterprise instance
- Add support for assignee
- Add support for "closed" state issues, using a 2 step processes where we first create the issue, then close it (useful for historical purposes when moving out from another issue tracker)
- Be a little bit more gentle on GitHub API (even slower rate throttling)
- Fixed a bug where token parameter was not taken into account on command line