### PR TITLE
fix: strip the UTF8 BOM

### DIFF
--- a/import.js
+++ b/import.js
@@ -13,6 +13,7 @@ const importFile = (octokit, file, values) => {
       data,
       {
         trim: true,
+        bom: true,
       },
       (err, csvRows) => {
         if (err) throw err;


### PR DESCRIPTION
The input file is read as UTF8, and in `csv-parse` documentation is written "It is recommended to always activate this option when working with UTF-8 files." (https://csv.js.org/parse/options/bom/).

This fixes the case where there is a BOM, in which case the first column was not detected, because it includes the BOM character as the first char of the first column name.

If the file has no BOM, then the option does nothing.