### PR TITLE
feat: option "--csvDelimiter <delimiter>"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For all actions, the tool will ask you to input a GitHub token. To obtain this t
 | -t, --token             | The GitHub token. <https://github.com/settings/tokens>                          |
 | -o, --organization      | The User or Organization slug that the repo lives under. <br />Example: For `/myOrg/my-repo`, this value would be **myOrg**.                    |
 | -r, --repository        | The repository name (slug).<br />Example: For `/myOrg/my-repo`, this value would be **my-repo**.                                                 |
+| --csvDelimiter          | The CSV delimiter character (defaults to ',')                                 |
 | -v, --verbose           | Include additional logging information.                                       |
 | -h, --help              | See all the options and help.                                                 |
 

--- a/import.js
+++ b/import.js
@@ -13,6 +13,7 @@ const importFile = (octokit, file, values) => {
       data,
       {
         trim: true,
+        delimiter: values.csvDelimiter,
       },
       (err, csvRows) => {
         if (err) throw err;

--- a/index.js
+++ b/index.js
@@ -35,7 +35,10 @@ program
   )
   .option("-c, --exportComments", "Include comments in the export.")
   .option("-e, --exportAll", "Include all data in the export.")
-  .option("-v, --verbose", "Include additional logging information.")
+  .option(
+    "--csvDelimiter [csvDelimiter]",
+    "CSV delimiter character (defaults to ',')"
+  )  .option("-v, --verbose", "Include additional logging information.")
   .action(function (file, options) {
     co(function* () {
       const retObject = {};
@@ -56,6 +59,7 @@ program
       }
       retObject.exportComments = options.exportComments || false;
       retObject.exportAll = options.exportAll || false;
+      retObject.csvDelimiter = options.csvDelimiter || ',';
       retObject.verbose = options.verbose || false;
 
       retObject.userOrOrganization = options.organization || "";

--- a/test/semicolonSeparator.csv
+++ b/test/semicolonSeparator.csv
@@ -1,0 +1,3 @@
+title;body;labels
+Test 1; This is the test1 desc; bug
+Test 2; This is the test2 desc; question


### PR DESCRIPTION
A lot of CVS files are deliimited by `;` instead of `,`, and some softwares don't allow exporting using `,` as a separator.

This PR adds an optional `--csvDelimiter` option that can be used to specify the delimited we want. It defaults as comma.

Usage: `githubCsvTools --csvDelimiter ';' ./myFileDelimitedByColons.csv`
