### PR TITLE
Milestone should be received as a number rather than string

### DIFF
--- a/import.js
+++ b/import.js
@@ -50,7 +50,7 @@ const importFile = (octokit, file, values) => {
 
           // if we have a milestone column, pass that.
           if (milestoneIndex > -1 && row[milestoneIndex] !== "") {
-            sendObj.issue.milestone = row[milestoneIndex];
+            sendObj.issue.milestone = Number(row[milestoneIndex]);
           }
 
           // if we have an assignee column, pass that.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "eslint *.js",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "start": "node ./index.js"
   },
   "bin": {
     "githubCsvTools": "./index.js"


### PR DESCRIPTION
Hey @gavinr thanks for creating this repo!

Here's a quick fix to Milestones (Github expects an integer for the Milestone, not a string) and added a `npm start` script so users who clone your repo can run locally. 