### PR TITLE
Fix import of issues without body message

### DIFF
--- a/import.js
+++ b/import.js
@@ -41,8 +41,14 @@ const importFile = (octokit, file, values) => {
           sendObj.issue.title = row[titleIndex];
 
           // if we have a body column, pass that.
-          if (bodyIndex > -1 && row[bodyIndex] !== "") {
-            sendObj.issue.body = row[bodyIndex];
+          if (bodyIndex > -1) {
+            if (row[bodyIndex] !== "") {
+              sendObj.issue.body = row[bodyIndex];
+            }
+            else {
+              // if the body is not defined, copy the title to the body of the issue
+              sendObj.issue.body = row[titleIndex];
+            }
           }
 
           // if we have a labels column, pass that.

--- a/test/emptyBodyLines.csv
+++ b/test/emptyBodyLines.csv
@@ -1,0 +1,3 @@
+title, body,labels
+Test 1, , bug
+Test 2, This is the test2 desc, question


### PR DESCRIPTION
The CSV import threw an error when an issue didn't have a body defined. Since it is a good practice to have a body defined, in the case of importing issues, we duplicate the title into the body. While this doesn't clarify the issue, it highlights the problem and still imports the issue.

Another option would be to remove the verification that the body is empty whatsoever, and if a body column exists, just add it the way it is, even if empty.