### PR TITLE
Support for import of issue with multiple assignees

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -2,14 +2,14 @@ const createIssue = (octokit, issueInfo, organization, repository) => {
   return new Promise((resolve, reject) => {
     octokit
       .request(
-        "POST /repos/" + organization + "/" + repository + "/import/issues",
+        "POST /repos/" + organization + "/" + repository + "/issues",
         issueInfo
       )
       .then(
         (res) => {
           // console.log("res", res);
-          if (res.status === 202) {
-            console.log(`Imported issue: ${issueInfo.issue.title}`);
+          if (res.status === 201) {
+            console.log(`Imported issue: ${issueInfo.title}`);
             resolve(res);
           } else {
             // error creating the issue
@@ -23,4 +23,29 @@ const createIssue = (octokit, issueInfo, organization, repository) => {
   });
 };
 
-module.exports = { createIssue };
+const updateIssue = (octokit, issueInfo, organization, repository, number) => {
+  return new Promise((resolve, reject) => {
+    octokit
+      .request(
+        "PATCH /repos/" + organization + "/" + repository + "/issues/" + number,
+        issueInfo
+      )
+      .then(
+        (res) => {
+          // console.log("res", res);
+          if (res.status === 200) {
+            console.log(`Updated issue: ${issueInfo.title}`);
+            resolve(res);
+          } else {
+            // error creating the issue
+            reject(res);
+          }
+        },
+        (err) => {
+          reject(err);
+        }
+      );
+  });
+};
+
+module.exports = { createIssue, updateIssue };

--- a/test/4.csv
+++ b/test/4.csv
@@ -1,3 +1,3 @@
-title,body,labels,assignee
+title,body,labels,assignees
 Test 1, This is the test1 desc, bug,github-user
-Test 2, This is the test2 desc, "question,bug",github-user
+Test 2, This is the test2 desc, "question,bug","github-user,another-github-user"

--- a/test/5.csv
+++ b/test/5.csv
@@ -1,4 +1,4 @@
-title,body,labels,assignee
+title,body,labels,assignees
 Test 1,This is a placeholder description.,bug,
 Test 2,This is a placeholder description.,"question,bug",
 Test 3,This is a placeholder description.,,


### PR DESCRIPTION
These changes removes the current limit of only a single assignee per issue during import. Using the /issues endpoint instead of the /import/issues endpoint to create (POST) a new issue, multiple assignees can be set at the same time. Because the /issues endpoint doesn't support setting the issue state, a "Closed" state triggers a PATCH /issues/number endpoint call to set the state to "closed"