### PR TITLE
Fix 'state' column in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Instructions for exporting or importing:
 
 ### To Import Issues
 
-Currently imports title, body, labels, status (closed or open) and milestones. See the [test](/test) folder for example input formats.
+Currently imports title, body, labels, state (closed or open) and milestones. See the [test](/test) folder for example input formats.
 
 ```bash
 githubCsvTools myFile.csv


### PR DESCRIPTION
The column `status` is ignored. The README should be corrected to use `state`.